### PR TITLE
adding 0 check -162

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBuffAllocator.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBuffAllocator.java
@@ -171,6 +171,9 @@ public class ByteBuffAllocator {
       // that by the time a handler originated response is actually done writing to socket and so
       // released the BBs it used, the handler might have processed one more read req. On an avg 2x
       // we consider and consider that also for the max buffers to pool
+      if (poolBufSize == 0) {
+        throw new IllegalArgumentException("poolBufSize cannot be zero");
+      }
       int bufsForTwoMB = (2 * 1024 * 1024) / poolBufSize;
       int maxBuffCount =
         conf.getInt(MAX_BUFFER_COUNT_KEY, conf.getInt(HConstants.REGION_SERVER_HANDLER_COUNT,


### PR DESCRIPTION
### What happened

There is no value checking for parameter `hbase.server.allocator.buffer.size`. This may cause improper calculations and crashes the system like division by 0.

### Buggy code

In `ByteBuffAllocator.java`, there is no value checking for `poolBufSize` and this variable is directly used to calculate the `bufsForTwoMB`. When `poolBufSize` is mistakenly set to 0, the code would cause division by 0 and throw ArithmeticException to crash the system.

```java
public static ByteBuffAllocator create(Configuration conf, boolean reservoirEnabled) {
    int poolBufSize = conf.getInt(BUFFER_SIZE_KEY, DEFAULT_BUFFER_SIZE);
    if (reservoirEnabled) {
    . . .
    int bufsForTwoMB = (2 * 1024 * 1024) / poolBufSize;
    . . .
```

So we added 0 check for `poolBufSize` as below :
```java
if (poolBufSize == 0) {
     throw new IllegalArgumentException("poolBufSize cannot be zero");
}
```