### PR TITLE
HBASE-27990 BucketCache causes ArithmeticException due to improper blockSize value checking -163

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCacheFactory.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCacheFactory.java
@@ -198,6 +198,10 @@ public final class BlockCacheFactory {
     }
 
     int blockSize = c.getInt(BLOCKCACHE_BLOCKSIZE_KEY, HConstants.DEFAULT_BLOCKSIZE);
+    if (blockSize <= 0) {
+      throw new IllegalStateException("blockSize <= 0; Check " + BLOCKCACHE_BLOCKSIZE_KEY
+        + " setting and/or server java heap size");
+    }
     final long bucketCacheSize = MemorySizeUtil.getBucketCacheSize(c);
     if (bucketCacheSize <= 0) {
       throw new IllegalStateException("bucketCacheSize <= 0; Check " + BUCKET_CACHE_SIZE_KEY

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
@@ -279,6 +279,7 @@ public class BucketCache implements BlockCache, HeapSize {
     this.algorithm = conf.get(FILE_VERIFY_ALGORITHM, DEFAULT_FILE_VERIFY_ALGORITHM);
     this.ioEngine = getIOEngineFromName(ioEngineName, capacity, persistencePath);
     this.writerThreads = new WriterThread[writerThreadNum];
+    
     if (blockSize == 0) {
       throw new IllegalArgumentException("blockSize cannot be zero");
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
@@ -279,10 +279,6 @@ public class BucketCache implements BlockCache, HeapSize {
     this.algorithm = conf.get(FILE_VERIFY_ALGORITHM, DEFAULT_FILE_VERIFY_ALGORITHM);
     this.ioEngine = getIOEngineFromName(ioEngineName, capacity, persistencePath);
     this.writerThreads = new WriterThread[writerThreadNum];
-    
-    if (blockSize <= 0) {
-      throw new IllegalArgumentException("blockSize cannot be zero or negative");
-    }
     long blockNumCapacity = capacity / blockSize;
     if (blockNumCapacity >= Integer.MAX_VALUE) {
       // Enough for about 32TB of cache!

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
@@ -280,8 +280,8 @@ public class BucketCache implements BlockCache, HeapSize {
     this.ioEngine = getIOEngineFromName(ioEngineName, capacity, persistencePath);
     this.writerThreads = new WriterThread[writerThreadNum];
     
-    if (blockSize == 0) {
-      throw new IllegalArgumentException("blockSize cannot be zero");
+    if (blockSize <= 0) {
+      throw new IllegalArgumentException("blockSize cannot be zero or negative");
     }
     long blockNumCapacity = capacity / blockSize;
     if (blockNumCapacity >= Integer.MAX_VALUE) {


### PR DESCRIPTION
## What happened
There is no value checking for parameter `hbase.blockcache.minblocksize`. This may cause improper calculations and crashes the system like division by 0.

## Buggy code
In `BucketCache.java`, there is no value checking for `blockSize` and this variable is directly used to calculate the `blockNumCapacity`. When `blockSize` is mistakenly set to 0, the code would cause division by 0 and throw ArithmeticException to crash the system.
```java
  public BucketCache(String ioEngineName, long capacity, int blockSize, int[] bucketSizes,
    int writerThreadNum, int writerQLen, String persistencePath, int ioErrorsTolerationDuration,
    Configuration conf) throws IOException {
    ...
    long blockNumCapacity = capacity / blockSize;
    ...
```

So we added check for `blockSize`.