### PR TITLE
HBASE-27993 AbstractFSWAL causes ArithmeticException due to improper logRollSize value checking -177

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBuffAllocator.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBuffAllocator.java
@@ -171,6 +171,9 @@ public class ByteBuffAllocator {
       // that by the time a handler originated response is actually done writing to socket and so
       // released the BBs it used, the handler might have processed one more read req. On an avg 2x
       // we consider and consider that also for the max buffers to pool
+      if (poolBufSize == 0) {
+       throw new IllegalArgumentException("BUFFER_SIZE_KEY cannot be zero");
+      }
       int bufsForTwoMB = (2 * 1024 * 1024) / poolBufSize;
       int maxBuffCount =
         conf.getInt(MAX_BUFFER_COUNT_KEY, conf.getInt(HConstants.REGION_SERVER_HANDLER_COUNT,

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
@@ -279,6 +279,7 @@ public class BucketCache implements BlockCache, HeapSize {
     this.algorithm = conf.get(FILE_VERIFY_ALGORITHM, DEFAULT_FILE_VERIFY_ALGORITHM);
     this.ioEngine = getIOEngineFromName(ioEngineName, capacity, persistencePath);
     this.writerThreads = new WriterThread[writerThreadNum];
+    
     if (blockSize == 0) {
       throw new IllegalArgumentException("blockSize cannot be zero");
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractFSWAL.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractFSWAL.java
@@ -464,7 +464,10 @@ public abstract class AbstractFSWAL<W extends WriterBase> implements WAL {
   private int calculateMaxLogFiles(Configuration conf, long logRollSize) {
     Pair<Long, MemoryType> globalMemstoreSize = MemorySizeUtil.getGlobalMemStoreSize(conf);
     if (logRollSize <= 0) {
-      throw new IllegalArgumentException("logRollSize cannot be zero or negative");
+      throw new IllegalStateException("logRollSize <= 0; Check " + WAL_ROLL_MULTIPLIER
+           + " setting and/or server java heap size");
+    }
+      throw new IllegalArgumentException("logRollSize <= 0 >");
     return (int) ((globalMemstoreSize.getFirst() * 2) / logRollSize);
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractFSWAL.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractFSWAL.java
@@ -463,6 +463,8 @@ public abstract class AbstractFSWAL<W extends WriterBase> implements WAL {
 
   private int calculateMaxLogFiles(Configuration conf, long logRollSize) {
     Pair<Long, MemoryType> globalMemstoreSize = MemorySizeUtil.getGlobalMemStoreSize(conf);
+    if (logRollSize <= 0) {
+      throw new IllegalArgumentException("logRollSize cannot be zero or negative");
     return (int) ((globalMemstoreSize.getFirst() * 2) / logRollSize);
   }
 


### PR DESCRIPTION
## What happened
There is no value checking for parameter `hbase.regionserver.logroll.multiplier` when `hbase.wal.provider` is set to `multiwal`. This may cause improper calculations and crashes the system like division by 0.

## Buggy code
In `AbstractFSWAL.java`, there is no value checking for `logRollSize ` and this variable is directly used while calculating the value of maxLogFiles in the method `calculateMaxLogFiles`. When set `logRollSize <= 0 `  mistakenly, the code would cause division by 0 and throw ArithmeticException to crash the system.
```java
     private int calculateMaxLogFiles(Configuration conf, long logRollSize) {
    Pair<Long, MemoryType> globalMemstoreSize = MemorySizeUtil.getGlobalMemStoreSize(conf);
    return (int) ((globalMemstoreSize.getFirst() * 2) / logRollSize);
  }
```

So we added checking for `logRollSize`.